### PR TITLE
Put .s in front of the nows.

### DIFF
--- a/layouts/partials/rush-event-single.html
+++ b/layouts/partials/rush-event-single.html
@@ -4,7 +4,7 @@
 {{ if eq $dateMissing false }}
 
     <span class="key">
-        {{ if ge .Date.Unix now.Unix }}
+        {{ if ge .Date.Unix .now.Unix }}
           starts
         {{ else }}
           started
@@ -33,7 +33,7 @@
   </div>
 
   <h1 class="headline" itemprop="headline">
-  {{ if ge .Date.Unix now.Unix  }} 
+  {{ if ge .Date.Unix .now.Unix  }} 
     [rush] 
   {{ else }}
     [rush - OLD]

--- a/layouts/section/rush.html
+++ b/layouts/section/rush.html
@@ -9,7 +9,7 @@
   {{ range .Data.Pages.GroupByDate "Monday, January 2" "asc"}}
     {{ $.Scratch.Set "displayDate" true }} 
     {{ range .Pages }}
-      {{ if not (ge .Date.Unix now.Unix)}}
+      {{ if not (ge .Date.Unix .now.Unix)}}
         <!--don't display the date if there are no current events-->
         {{ $.Scratch.Set "displayDate" false }} 
         <!--only render the old section if there are expired events-->
@@ -19,7 +19,7 @@
     {{ if $.Scratch.Get "displayDate" }}
       <h2 class="list-key">{{ .Key }}</h2>
       {{ range .Pages }}
-        {{ if ge .Date.Unix now.Unix}}
+        {{ if ge .Date.Unix .now.Unix}}
           {{ partial "rush-event-list-entry.html" . }}
         {{ end }}
       {{ end }}
@@ -35,7 +35,7 @@
         {{ range .Data.Pages.GroupByDate "Monday, January 2" "asc"}}
           {{ $.Scratch.Set "displayDate" false }}
           {{ range .Pages }}
-            {{ if lt .Date.Unix now.Unix}}
+            {{ if lt .Date.Unix .now.Unix}}
               <!--only display the date if there are expired events-->
               {{ $.Scratch.Set "displayDate" true }}
             {{ end }}
@@ -43,7 +43,7 @@
           {{ if $.Scratch.Get "displayDate" }}
             <h2 class="list-key">{{ .Key }}</h2>
             {{ range .Pages }}
-              {{ if lt .Date.Unix now.Unix}}
+              {{ if lt .Date.Unix .now.Unix}}
                 <div class="old">
                   {{ partial "rush-event-list-entry.html" . }}
                 </div>


### PR DESCRIPTION
I can't locally debug because npm gives me

> static-fp@1.0.0 start /home/jselover/Projects/static-fp
> parallelshell 'npm run watch' 'hugo server'

child_process.js:400
    throw new TypeError('"cwd" must be a string');
    ^

TypeError: "cwd" must be a string
    at normalizeSpawnArguments (child_process.js:400:11)
    at exports.spawn (child_process.js:487:38)
    at /home/jselover/Projects/static-fp/node_modules/parallelshell/index.js:104:17
    at Array.forEach (<anonymous>)
    at Object.<anonymous> (/home/jselover/Projects/static-fp/node_modules/parallelshell/index.js:100:6)
    at Module._compile (module.js:573:30)
    at Object.Module._extensions..js (module.js:584:10)
    at Module.load (module.js:507:32)
    at tryModuleLoad (module.js:470:12)
    at Function.Module._load (module.js:462:3)
